### PR TITLE
feat: Withdraw Intent

### DIFF
--- a/src/intents/WithdrawBridgeIntent.sol
+++ b/src/intents/WithdrawBridgeIntent.sol
@@ -20,7 +20,6 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
     /// @notice The maximum fee for a token for single withdraw
     mapping(address user => mapping(address token => uint256 maxFee)) public maxFee;
 
-    
     /// @notice The valid recipients for the withdraw intent
     mapping(address user => mapping(address recipient => bool isValid)) public validRecipients;
 

--- a/src/intents/WithdrawBridgeIntent.sol
+++ b/src/intents/WithdrawBridgeIntent.sol
@@ -99,7 +99,7 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
         onlyIntentExecutor
     {
         IERC20(token).transferFrom(scw, address(this), amount);
-        IERC20(token).approve(address(SOCKET_BRIDGE), amount);
+        IERC20(token).approve(address(IOFT_BRIDGE), amount);
 
         // The auto execution can only be triggered if the fee is less than the max fee set by the user
         uint256 feeInToken = IOFT_BRIDGE.getFeeInToken(token, amount, destEID);

--- a/src/intents/WithdrawBridgeIntent.sol
+++ b/src/intents/WithdrawBridgeIntent.sol
@@ -17,14 +17,11 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
 
     IOFTWithdrawWrapper public immutable IOFT_BRIDGE;
 
-    /**
-     * @notice The maximum fee for a token for single withdraw
-     */
+    /// @notice The maximum fee for a token for single withdraw
     mapping(address user => mapping(address token => uint256 maxFee)) public maxFee;
 
-    /**
-     * @notice The valid recipients for the withdraw intent
-     */
+    
+    /// @notice The valid recipients for the withdraw intent
     mapping(address user => mapping(address recipient => bool isValid)) public validRecipients;
 
     error InvalidRecipient();
@@ -45,7 +42,7 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
 
     event MaxFeeSet(address indexed user, address indexed token, uint256 maxFee);
 
-    event ValidRecipientSet(address indexed user, address indexed recipient);
+    event ValidRecipientSet(address indexed user, address indexed recipient, bool isValid);
 
     constructor(ISocketWithdrawWrapper _socketBridge, IOFTWithdrawWrapper _iOFTBridge) {
         SOCKET_BRIDGE = _socketBridge;
@@ -133,9 +130,9 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
      * @notice Set the valid recipient for all withdraw intent
      * @param recipient The recipient address
      */
-    function setValidRecipient(address recipient) external {
-        validRecipients[msg.sender][recipient] = true;
+    function setValidRecipient(address recipient, bool isValid) external {
+        validRecipients[msg.sender][recipient] = isValid;
 
-        emit ValidRecipientSet(msg.sender, recipient);
+        emit ValidRecipientSet(msg.sender, recipient, isValid);
     }
 }

--- a/src/intents/WithdrawBridgeIntent.sol
+++ b/src/intents/WithdrawBridgeIntent.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import {IERC20} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "../../lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
+import {IntentExecutorBase} from "./IntentExecutorBase.sol";
+import {ILightAccount} from "../interfaces/ILightAccount.sol";
+import {LyraWithdrawWrapperV2New} from "../withdraw/LyraWithdrawWrapperV2New.sol";
+/**
+ * @title  WithdrawBridgeIntent
+ * @notice A shared contract that allows authorized user to withdraw from LightAccount to off
+ * @dev    Users who wish to have the auto-withdraw feature need to approve this contract to spend their tokens
+ */
+contract WithdrawBridgeIntent is IntentExecutorBase {
+    
+    IERC721 public immutable SUBACCOUNTS;
+    LyraWithdrawWrapperV2New public immutable WITHDRAW_WRAPPER;
+
+    /**
+     * @notice The maximum fee for a token for single withdraw
+     */
+    mapping(address user => mapping(address token => uint256 maxFee)) public maxFee;
+
+    error FeeTooHigh();
+
+    event IntentWithdraw(
+      address indexed scw, 
+      address indexed token, 
+      uint256 amount,
+      address controller,
+      address connector
+    );
+
+    event MaxFeeSet(address indexed user, address indexed token, uint256 maxFee);
+
+    constructor(IERC721 _subaccounts) {
+        SUBACCOUNTS = _subaccounts;
+    }
+
+    /**
+     * @notice Execute a withdraw intent to auto bridge tokens off Derive.
+     * @dev    The SCW must have approved this contract to spend the token, and set max fee for each token.
+     * @param scw The light account address
+     * @param token The ERC20 token address
+     * @param amount The amount of tokens to withdraw
+     * @param controller The Socket Controller address
+     * @param connector The Socket Connector address
+     */
+    function executeWithdrawIntent(
+      address scw,
+      address token, 
+      uint256 amount, 
+      address controller, 
+      address connector,
+      uint256 gasLimit
+    )
+        external
+        onlyIntentExecutor
+    {
+        
+        IERC20(token).transferFrom(scw, address(this), amount);
+        IERC20(token).approve(address(WITHDRAW_WRAPPER), amount);
+
+        // The auto execution can only be triggered if the fee is less than the max fee set by the user
+        uint256 feeInToken = WITHDRAW_WRAPPER.getFeeInToken(token, controller, connector, gasLimit);
+        if (feeInToken > maxFee[scw][token]) revert FeeTooHigh();
+
+        address recipient = ILightAccount(scw).owner();
+
+        WITHDRAW_WRAPPER.withdrawToChain(
+          token,
+          amount,
+          recipient,
+          controller,
+          connector,
+          gasLimit
+        );
+
+        emit IntentWithdraw(scw, token, amount, controller, connector);
+    }
+
+    /**
+     * @notice Set the maximum fee for a token for single withdraw
+     * @param token The token address
+     * @param _maxFee The maximum fee for the withdraw bridge
+     */
+    function setMaxFee(address token, uint256 _maxFee) external {
+      maxFee[msg.sender][token] = _maxFee;
+
+      emit MaxFeeSet(msg.sender, token, _maxFee);
+    }
+}

--- a/src/intents/WithdrawBridgeIntent.sol
+++ b/src/intents/WithdrawBridgeIntent.sol
@@ -2,39 +2,54 @@
 pragma solidity ^0.8.9;
 
 import {IERC20} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {IERC721} from "../../lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
 import {IntentExecutorBase} from "./IntentExecutorBase.sol";
 import {ILightAccount} from "../interfaces/ILightAccount.sol";
-import {LyraWithdrawWrapperV2New} from "../withdraw/LyraWithdrawWrapperV2New.sol";
+import {ISocketWithdrawWrapper} from "../interfaces/derive/ISocketWithdrawWrapper.sol";
+import {IOFTWithdrawWrapper} from "../interfaces/derive/IOFTWithdrawWrapper.sol";
+
 /**
  * @title  WithdrawBridgeIntent
  * @notice A shared contract that allows authorized user to withdraw from LightAccount to off
  * @dev    Users who wish to have the auto-withdraw feature need to approve this contract to spend their tokens
  */
 contract WithdrawBridgeIntent is IntentExecutorBase {
-    
-    IERC721 public immutable SUBACCOUNTS;
-    LyraWithdrawWrapperV2New public immutable WITHDRAW_WRAPPER;
+    ISocketWithdrawWrapper public immutable SOCKET_BRIDGE;
+
+    IOFTWithdrawWrapper public immutable IOFT_BRIDGE;
 
     /**
      * @notice The maximum fee for a token for single withdraw
      */
     mapping(address user => mapping(address token => uint256 maxFee)) public maxFee;
 
+    /**
+     * @notice The valid recipients for the withdraw intent
+     */
+    mapping(address user => mapping(address recipient => bool isValid)) public validRecipients;
+
+    error InvalidRecipient();
     error FeeTooHigh();
 
-    event IntentWithdraw(
-      address indexed scw, 
-      address indexed token, 
-      uint256 amount,
-      address controller,
-      address connector
+    event IntentWithdrawSocket(
+        address indexed scw,
+        address indexed token,
+        uint256 amount,
+        address recipient,
+        address controller,
+        address connector
+    );
+
+    event IntentWithdrawLZ(
+        address indexed scw, address indexed token, uint256 amount, address recipient, uint32 destEID
     );
 
     event MaxFeeSet(address indexed user, address indexed token, uint256 maxFee);
 
-    constructor(IERC721 _subaccounts) {
-        SUBACCOUNTS = _subaccounts;
+    event ValidRecipientSet(address indexed user, address indexed recipient);
+
+    constructor(ISocketWithdrawWrapper _socketBridge, IOFTWithdrawWrapper _iOFTBridge) {
+        SOCKET_BRIDGE = _socketBridge;
+        IOFT_BRIDGE = _iOFTBridge;
     }
 
     /**
@@ -43,40 +58,64 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
      * @param scw The light account address
      * @param token The ERC20 token address
      * @param amount The amount of tokens to withdraw
+     * @param recipient The recipient address, must be a valid recipient or the owner of the SCW
      * @param controller The Socket Controller address
      * @param connector The Socket Connector address
      */
-    function executeWithdrawIntent(
-      address scw,
-      address token, 
-      uint256 amount, 
-      address controller, 
-      address connector,
-      uint256 gasLimit
-    )
+    function executeWithdrawIntentSocket(
+        address scw,
+        address token,
+        uint256 amount,
+        address recipient,
+        address controller,
+        address connector,
+        uint256 gasLimit
+    ) external onlyIntentExecutor {
+        IERC20(token).transferFrom(scw, address(this), amount);
+        IERC20(token).approve(address(SOCKET_BRIDGE), amount);
+
+        // The auto execution can only be triggered if the fee is less than the max fee set by the user
+        uint256 feeInToken = SOCKET_BRIDGE.getFeeInToken(token, controller, connector, gasLimit);
+        if (feeInToken > maxFee[scw][token]) revert FeeTooHigh();
+
+        // The recipient must be pre-approved, or be the owner of the SCW
+        if (!validRecipients[scw][recipient] && ILightAccount(scw).owner() != recipient) {
+            revert InvalidRecipient();
+        }
+
+        SOCKET_BRIDGE.withdrawToChain(token, amount, recipient, controller, connector, gasLimit);
+
+        emit IntentWithdrawSocket(scw, token, amount, recipient, controller, connector);
+    }
+
+    /**
+     * @notice Execute a withdraw intent to auto bridge tokens off Derive through LayerZero OFT Wrapper.
+     * @dev    The SCW must have approved this contract to spend the token, and set max fee for each token.
+     * @param scw The light account address
+     * @param token The ERC20 token address
+     * @param amount The amount of tokens to withdraw
+     * @param recipient The recipient address, must be a valid recipient or the owner of the SCW
+     * @param destEID The destination EID
+     */
+    function executeWithdrawIntentLZ(address scw, address token, uint256 amount, address recipient, uint32 destEID)
         external
         onlyIntentExecutor
     {
-        
         IERC20(token).transferFrom(scw, address(this), amount);
-        IERC20(token).approve(address(WITHDRAW_WRAPPER), amount);
+        IERC20(token).approve(address(SOCKET_BRIDGE), amount);
 
         // The auto execution can only be triggered if the fee is less than the max fee set by the user
-        uint256 feeInToken = WITHDRAW_WRAPPER.getFeeInToken(token, controller, connector, gasLimit);
+        uint256 feeInToken = IOFT_BRIDGE.getFeeInToken(token, amount, destEID);
         if (feeInToken > maxFee[scw][token]) revert FeeTooHigh();
 
-        address recipient = ILightAccount(scw).owner();
+        // The recipient must be pre-approved, or be the owner of the SCW
+        if (!validRecipients[scw][recipient] && ILightAccount(scw).owner() != recipient) {
+            revert InvalidRecipient();
+        }
 
-        WITHDRAW_WRAPPER.withdrawToChain(
-          token,
-          amount,
-          recipient,
-          controller,
-          connector,
-          gasLimit
-        );
+        IOFT_BRIDGE.withdrawToChain(token, amount, recipient, destEID);
 
-        emit IntentWithdraw(scw, token, amount, controller, connector);
+        emit IntentWithdrawLZ(scw, token, amount, recipient, destEID);
     }
 
     /**
@@ -85,8 +124,18 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
      * @param _maxFee The maximum fee for the withdraw bridge
      */
     function setMaxFee(address token, uint256 _maxFee) external {
-      maxFee[msg.sender][token] = _maxFee;
+        maxFee[msg.sender][token] = _maxFee;
 
-      emit MaxFeeSet(msg.sender, token, _maxFee);
+        emit MaxFeeSet(msg.sender, token, _maxFee);
+    }
+
+    /**
+     * @notice Set the valid recipient for all withdraw intent
+     * @param recipient The recipient address
+     */
+    function setValidRecipient(address recipient) external {
+        validRecipients[msg.sender][recipient] = true;
+
+        emit ValidRecipientSet(msg.sender, recipient);
     }
 }

--- a/src/intents/WithdrawBridgeIntent.sol
+++ b/src/intents/WithdrawBridgeIntent.sol
@@ -9,19 +9,18 @@ import {IOFTWithdrawWrapper} from "../interfaces/derive/IOFTWithdrawWrapper.sol"
 
 /**
  * @title  WithdrawBridgeIntent
- * @notice A shared contract that allows authorized user to withdraw from LightAccount to off
+ * @notice A shared contract that allows executor to help users to withdraw tokens from LightAccount off Derive through bridges
  * @dev    Users who wish to have the auto-withdraw feature need to approve this contract to spend their tokens
+ *
+ * @dev    Trust Assumptions:
+ *         - Users must trust the executor not to arbitrarily execute withdrawals.
+ *         - Users must trust the owner to not add malicious executor
+ *         - Users rely on executors to provide a valid maxFee for each action to avoid being charged high fees by bridges.
  */
 contract WithdrawBridgeIntent is IntentExecutorBase {
     ISocketWithdrawWrapper public immutable SOCKET_BRIDGE;
 
     IOFTWithdrawWrapper public immutable IOFT_BRIDGE;
-
-    /// @notice The maximum fee for a token for single withdraw
-    mapping(address user => mapping(address token => uint256 maxFee)) public maxFee;
-
-    /// @notice The valid recipients for the withdraw intent
-    mapping(address user => mapping(address recipient => bool isValid)) public validRecipients;
 
     error InvalidRecipient();
     error FeeTooHigh();
@@ -39,10 +38,6 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
         address indexed scw, address indexed token, uint256 amount, address recipient, uint32 destEID
     );
 
-    event MaxFeeSet(address indexed user, address indexed token, uint256 maxFee);
-
-    event ValidRecipientSet(address indexed user, address indexed recipient, bool isValid);
-
     constructor(ISocketWithdrawWrapper _socketBridge, IOFTWithdrawWrapper _iOFTBridge) {
         SOCKET_BRIDGE = _socketBridge;
         IOFT_BRIDGE = _iOFTBridge;
@@ -54,7 +49,7 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
      * @param scw The light account address
      * @param token The ERC20 token address
      * @param amount The amount of tokens to withdraw
-     * @param recipient The recipient address, must be a valid recipient or the owner of the SCW
+     * @param recipient The recipient address, must specify explictly as the SCW owner
      * @param controller The Socket Controller address
      * @param connector The Socket Connector address
      */
@@ -62,6 +57,7 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
         address scw,
         address token,
         uint256 amount,
+        uint256 maxFee,
         address recipient,
         address controller,
         address connector,
@@ -71,11 +67,13 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
         IERC20(token).approve(address(SOCKET_BRIDGE), amount);
 
         // The auto execution can only be triggered if the fee is less than the max fee set by the user
-        uint256 feeInToken = SOCKET_BRIDGE.getFeeInToken(token, controller, connector, gasLimit);
-        if (feeInToken > maxFee[scw][token]) revert FeeTooHigh();
+        if (maxFee > 0) {
+            uint256 feeInToken = SOCKET_BRIDGE.getFeeInToken(token, controller, connector, gasLimit);
+            if (feeInToken > maxFee) revert FeeTooHigh();
+        }
 
-        // The recipient must be pre-approved, or be the owner of the SCW
-        if (!validRecipients[scw][recipient] && ILightAccount(scw).owner() != recipient) {
+        // The recipient must be the owner of the SCW
+        if (ILightAccount(scw).owner() != recipient) {
             revert InvalidRecipient();
         }
 
@@ -90,48 +88,34 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
      * @param scw The light account address
      * @param token The ERC20 token address
      * @param amount The amount of tokens to withdraw
+     * @param maxFee The maximum fee for the withdraw bridge
      * @param recipient The recipient address, must be a valid recipient or the owner of the SCW
      * @param destEID The destination EID
      */
-    function executeWithdrawIntentLZ(address scw, address token, uint256 amount, address recipient, uint32 destEID)
-        external
-        onlyIntentExecutor
-    {
+    function executeWithdrawIntentLZ(
+        address scw,
+        address token,
+        uint256 amount,
+        uint256 maxFee,
+        address recipient,
+        uint32 destEID
+    ) external onlyIntentExecutor {
         IERC20(token).transferFrom(scw, address(this), amount);
         IERC20(token).approve(address(IOFT_BRIDGE), amount);
 
         // The auto execution can only be triggered if the fee is less than the max fee set by the user
-        uint256 feeInToken = IOFT_BRIDGE.getFeeInToken(token, amount, destEID);
-        if (feeInToken > maxFee[scw][token]) revert FeeTooHigh();
+        if (maxFee > 0) {
+            uint256 feeInToken = IOFT_BRIDGE.getFeeInToken(token, amount, destEID);
+            if (feeInToken > maxFee) revert FeeTooHigh();
+        }
 
-        // The recipient must be pre-approved, or be the owner of the SCW
-        if (!validRecipients[scw][recipient] && ILightAccount(scw).owner() != recipient) {
+        // The recipient must be the owner of the SCW
+        if (ILightAccount(scw).owner() != recipient) {
             revert InvalidRecipient();
         }
 
         IOFT_BRIDGE.withdrawToChain(token, amount, recipient, destEID);
 
         emit IntentWithdrawLZ(scw, token, amount, recipient, destEID);
-    }
-
-    /**
-     * @notice Set the maximum fee for a token for single withdraw
-     * @param token The token address
-     * @param _maxFee The maximum fee for the withdraw bridge
-     */
-    function setMaxFee(address token, uint256 _maxFee) external {
-        maxFee[msg.sender][token] = _maxFee;
-
-        emit MaxFeeSet(msg.sender, token, _maxFee);
-    }
-
-    /**
-     * @notice Set the valid recipient for all withdraw intent
-     * @param recipient The recipient address
-     */
-    function setValidRecipient(address recipient, bool isValid) external {
-        validRecipients[msg.sender][recipient] = isValid;
-
-        emit ValidRecipientSet(msg.sender, recipient, isValid);
     }
 }

--- a/src/interfaces/ILightAccount.sol
+++ b/src/interfaces/ILightAccount.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+
+interface ILightAccount {
+    function owner() external view returns (address);
+}

--- a/src/interfaces/derive/IOFTWithdrawWrapper.sol
+++ b/src/interfaces/derive/IOFTWithdrawWrapper.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.18;
+
+import "openzeppelin/token/ERC20/extensions/IERC20Metadata.sol";
+
+interface IOFTWithdrawWrapper {
+    function withdrawToChain(address token, uint256 amount, address toAddress, uint32 destEID) external;
+
+    function getFeeInToken(address token, uint256 amount, uint32 destEID) external view returns (uint256);
+}

--- a/src/interfaces/derive/ISocketWithdrawWrapper.sol
+++ b/src/interfaces/derive/ISocketWithdrawWrapper.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.18;
+
+import "openzeppelin/token/ERC20/extensions/IERC20Metadata.sol";
+
+interface ISocketWithdrawWrapper {
+    function withdrawToChain(
+        address token,
+        uint256 amount,
+        address recipient,
+        address socketController,
+        address connector,
+        uint256 gasLimit
+    ) external;
+
+    function getFeeInToken(address token, address controller, address connector, uint256 gasLimit)
+        external
+        view
+        returns (uint256);
+}

--- a/test/fork-tests/intent/WithdrawBridgeIntent.t.sol
+++ b/test/fork-tests/intent/WithdrawBridgeIntent.t.sol
@@ -16,7 +16,6 @@ import {ILightAccount} from "src/interfaces/ILightAccount.sol";
  */
 
 contract FORK_LYRA_WithdrawBridgeIntent is Test {
-    
     address public weETH = address(0x7B35b4c05a90Ea5f311AeC815BE4148b446a68a2);
     address public drv = address(0x2EE0fd70756EDC663AcC9676658A1497C247693A);
 
@@ -54,7 +53,6 @@ contract FORK_LYRA_WithdrawBridgeIntent is Test {
         // set executor as intent executor
         bridgeIntent.setIntentExecutor(executor, true);
 
-
         // scw approves bridgeIntent to spend weETH
         vm.startPrank(scw);
         IERC20(weETH).approve(address(bridgeIntent), type(uint256).max);
@@ -73,7 +71,9 @@ contract FORK_LYRA_WithdrawBridgeIntent is Test {
         uint256 erc20BalanceBefore = IERC20(weETH).balanceOf(scw);
 
         vm.startPrank(executor);
-        bridgeIntent.executeWithdrawIntentSocket(scw, weETH, 1 ether, validRecipient, weETHController, weETHConnector, 200000);
+        bridgeIntent.executeWithdrawIntentSocket(
+            scw, weETH, 1 ether, validRecipient, weETHController, weETHConnector, 200000
+        );
         vm.stopPrank();
 
         uint256 erc20BalanceAfter = IERC20(weETH).balanceOf(scw);

--- a/test/fork-tests/intent/WithdrawBridgeIntent.t.sol
+++ b/test/fork-tests/intent/WithdrawBridgeIntent.t.sol
@@ -30,7 +30,6 @@ contract FORK_LYRA_WithdrawBridgeIntent is Test {
 
     // Mock scws
     address public scw = address(0x8dC92fB0e1C1F1Def6e424E50aaA66dbB124eb54);
-    address public validRecipient = address(0xb0ba);
 
     WithdrawBridgeIntent public bridgeIntent;
 
@@ -58,36 +57,19 @@ contract FORK_LYRA_WithdrawBridgeIntent is Test {
         IERC20(weETH).approve(address(bridgeIntent), type(uint256).max);
         IERC20(drv).approve(address(bridgeIntent), type(uint256).max);
 
-        // scw set max fee + recipient on bridgeintent
-        bridgeIntent.setMaxFee(weETH, 0.01 ether);
-        bridgeIntent.setMaxFee(drv, 5 ether); // 5 DRV
-
-        bridgeIntent.setValidRecipient(validRecipient, true);
-
         vm.stopPrank();
     }
 
     function testWithdrawIntent_weETH() public onlyDeriveMainnet {
-        uint256 erc20BalanceBefore = IERC20(weETH).balanceOf(scw);
-
-        vm.startPrank(executor);
-        bridgeIntent.executeWithdrawIntentSocket(
-            scw, weETH, 1 ether, validRecipient, weETHController, weETHConnector, 200000
-        );
-        vm.stopPrank();
-
-        uint256 erc20BalanceAfter = IERC20(weETH).balanceOf(scw);
-        assertEq(erc20BalanceAfter, erc20BalanceBefore - 1 ether);
-    }
-
-    function testWithdrawIntent_weETH_ToOwner() public onlyDeriveMainnet {
         // test we can withdraw to SCW owner
         address owner = ILightAccount(scw).owner();
 
         uint256 erc20BalanceBefore = IERC20(weETH).balanceOf(scw);
 
         vm.startPrank(executor);
-        bridgeIntent.executeWithdrawIntentSocket(scw, weETH, 1 ether, owner, weETHController, weETHConnector, 200000);
+        bridgeIntent.executeWithdrawIntentSocket(
+            scw, weETH, 1 ether, 0.1 ether, owner, weETHController, weETHConnector, 200000
+        );
         vm.stopPrank();
 
         uint256 erc20BalanceAfter = IERC20(weETH).balanceOf(scw);
@@ -97,8 +79,11 @@ contract FORK_LYRA_WithdrawBridgeIntent is Test {
     function testWithdrawIntent_DRV() public onlyDeriveMainnet {
         uint256 erc20BalanceBefore = IERC20(drv).balanceOf(scw);
 
+        uint256 maxFee = 10e18; // 10 DRV
+        address owner = ILightAccount(scw).owner();
+
         vm.startPrank(executor);
-        bridgeIntent.executeWithdrawIntentLZ(scw, drv, 10 ether, validRecipient, 30184);
+        bridgeIntent.executeWithdrawIntentLZ(scw, drv, 10 ether, maxFee, owner, 30184);
         vm.stopPrank();
 
         uint256 erc20BalanceAfter = IERC20(drv).balanceOf(scw);

--- a/test/fork-tests/intent/WithdrawBridgeIntent.t.sol
+++ b/test/fork-tests/intent/WithdrawBridgeIntent.t.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: UNLICENSED
+// solhint-disable contract-name-camelcase
+// solhint-disable func-name-mixedcase
+
+pragma solidity ^0.8.18;
+
+import {Test} from "lib/forge-std/src/Test.sol";
+
+import {WithdrawBridgeIntent} from "src/intents/WithdrawBridgeIntent.sol";
+import {IERC20} from "../../../lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {ISocketWithdrawWrapper} from "src/interfaces/derive/ISocketWithdrawWrapper.sol";
+import {IOFTWithdrawWrapper} from "src/interfaces/derive/IOFTWithdrawWrapper.sol";
+import {ILightAccount} from "src/interfaces/ILightAccount.sol";
+/**
+ * forge test --fork-url https://rpc.lyra.finance -vvv
+ */
+
+contract FORK_LYRA_WithdrawBridgeIntent is Test {
+    
+    address public weETH = address(0x7B35b4c05a90Ea5f311AeC815BE4148b446a68a2);
+
+    address public drv = address(0x2EE0fd70756EDC663AcC9676658A1497C247693A);
+
+    // OFT withdraw wrapper
+    IOFTWithdrawWrapper public oftBridge = IOFTWithdrawWrapper(0x9400cc156dad38a716047a67c897973A29A06710);
+
+    // Socket withdraw wrapper
+    ISocketWithdrawWrapper public socketBridge = ISocketWithdrawWrapper(0xea8E683D8C46ff05B871822a00461995F93df800);
+    // Socket Parameters
+    address public weETHController = address(0xf58fF1Adc4d045e712a6D91e69d93B4092516659);
+    address public weETHConnector = address(0x6Ee9b6ad1c97AdeeD071fd5f349cE65f91e43333);
+
+    // Mock scws
+    address public scw = address(0x8dC92fB0e1C1F1Def6e424E50aaA66dbB124eb54);
+    address public validRecipient = address(0xb0ba);
+
+    WithdrawBridgeIntent public bridgeIntent;
+
+    address public executor = address(0xb0b);
+
+    /**
+     * Only run the test when running with --fork flag, and connected to Lyra mainnet
+     */
+    modifier onlyDeriveMainnet() {
+        if (block.chainid != 957) return;
+        _;
+    }
+
+    function setUp() public onlyDeriveMainnet {
+        bridgeIntent = new WithdrawBridgeIntent(socketBridge, oftBridge);
+
+        deal(weETH, scw, 10 ether);
+
+        // set executor as intent executor
+        bridgeIntent.setIntentExecutor(executor, true);
+
+
+        // scw approves bridgeIntent to spend weETH
+        vm.startPrank(scw);
+        IERC20(weETH).approve(address(bridgeIntent), type(uint256).max);
+
+        // scw set max fee + recipient on bridgeintent
+        bridgeIntent.setMaxFee(weETH, 0.01 ether);
+        bridgeIntent.setValidRecipient(validRecipient, true);
+
+        vm.stopPrank();
+    }
+
+    function testWithdrawIntent_weETH() public onlyDeriveMainnet {
+        uint256 erc20BalanceBefore = IERC20(weETH).balanceOf(scw);
+
+        vm.startPrank(executor);
+        bridgeIntent.executeWithdrawIntentSocket(scw, weETH, 1 ether, validRecipient, weETHController, weETHConnector, 200000);
+        vm.stopPrank();
+
+        uint256 erc20BalanceAfter = IERC20(weETH).balanceOf(scw);
+        assertEq(erc20BalanceAfter, erc20BalanceBefore - 1 ether);
+    }
+
+    function testWithdrawIntent_weETH_ToOwner() public onlyDeriveMainnet {
+        // test we can withdraw to SCW owner
+        address owner = ILightAccount(scw).owner();
+
+        uint256 erc20BalanceBefore = IERC20(weETH).balanceOf(scw);
+
+        vm.startPrank(executor);
+        bridgeIntent.executeWithdrawIntentSocket(scw, weETH, 1 ether, owner, weETHController, weETHConnector, 200000);
+        vm.stopPrank();
+
+        uint256 erc20BalanceAfter = IERC20(weETH).balanceOf(scw);
+        assertEq(erc20BalanceAfter, erc20BalanceBefore - 1 ether);
+    }
+
+    receive() external payable {}
+}

--- a/test/fork-tests/intent/WithdrawBridgeIntent.t.sol
+++ b/test/fork-tests/intent/WithdrawBridgeIntent.t.sol
@@ -18,7 +18,6 @@ import {ILightAccount} from "src/interfaces/ILightAccount.sol";
 contract FORK_LYRA_WithdrawBridgeIntent is Test {
     
     address public weETH = address(0x7B35b4c05a90Ea5f311AeC815BE4148b446a68a2);
-
     address public drv = address(0x2EE0fd70756EDC663AcC9676658A1497C247693A);
 
     // OFT withdraw wrapper
@@ -50,6 +49,7 @@ contract FORK_LYRA_WithdrawBridgeIntent is Test {
         bridgeIntent = new WithdrawBridgeIntent(socketBridge, oftBridge);
 
         deal(weETH, scw, 10 ether);
+        deal(drv, scw, 1000 ether);
 
         // set executor as intent executor
         bridgeIntent.setIntentExecutor(executor, true);
@@ -58,9 +58,12 @@ contract FORK_LYRA_WithdrawBridgeIntent is Test {
         // scw approves bridgeIntent to spend weETH
         vm.startPrank(scw);
         IERC20(weETH).approve(address(bridgeIntent), type(uint256).max);
+        IERC20(drv).approve(address(bridgeIntent), type(uint256).max);
 
         // scw set max fee + recipient on bridgeintent
         bridgeIntent.setMaxFee(weETH, 0.01 ether);
+        bridgeIntent.setMaxFee(drv, 5 ether); // 5 DRV
+
         bridgeIntent.setValidRecipient(validRecipient, true);
 
         vm.stopPrank();
@@ -89,6 +92,17 @@ contract FORK_LYRA_WithdrawBridgeIntent is Test {
 
         uint256 erc20BalanceAfter = IERC20(weETH).balanceOf(scw);
         assertEq(erc20BalanceAfter, erc20BalanceBefore - 1 ether);
+    }
+
+    function testWithdrawIntent_DRV() public onlyDeriveMainnet {
+        uint256 erc20BalanceBefore = IERC20(drv).balanceOf(scw);
+
+        vm.startPrank(executor);
+        bridgeIntent.executeWithdrawIntentLZ(scw, drv, 10 ether, validRecipient, 30184);
+        vm.stopPrank();
+
+        uint256 erc20BalanceAfter = IERC20(drv).balanceOf(scw);
+        assertEq(erc20BalanceAfter, erc20BalanceBefore - 10 ether);
     }
 
     receive() external payable {}


### PR DESCRIPTION
## TLDR
* Allow users to set a maximum fee per token, so they won't get rekt if the executor sets a high withdrawal fee and auto-executes the withdrawal.
* Users need to explicitly set the receiver if the address is not the owner of the SCW.