### PR TITLE
fix: [audit-m1] rugpull by exploited executor key with malicious Derive Asset

### DIFF
--- a/src/intents/SubaccountDepositIntent.sol
+++ b/src/intents/SubaccountDepositIntent.sol
@@ -19,8 +19,14 @@ contract SubaccountDepositIntent is IntentExecutorBase {
     IMatching public immutable MATCHING;
 
     error SubaccountOwnerMismatch();
+    error DeriveAssetNotAllowed();
 
     event IntentDeposit(uint256 indexed subaccountId, address indexed scw, address indexed token, uint256 amount);
+
+    event AllowedDeriveAssetSet(address indexed deriveAsset, bool indexed allowed);
+
+    // Derive v2 asset addresses that are allowed to be deposited for intent executors
+    mapping(address => bool) public allowedDeriveAsset;
 
     constructor(IMatching _matching) {
         MATCHING = _matching;
@@ -40,6 +46,9 @@ contract SubaccountDepositIntent is IntentExecutorBase {
         // Can only deposit to subaccounts that are owned by the SCW
         _verifySubaccountOwner(subaccountId, scw);
 
+        // Can only deposit to derive v2 assets that are allowed
+        if (!allowedDeriveAsset[deriveAsset]) revert DeriveAssetNotAllowed();
+
         IERC20 token = IERC20BasedAsset(deriveAsset).wrappedAsset();
         token.safeTransferFrom(scw, address(this), amount);
         token.safeApprove(address(deriveAsset), amount);
@@ -56,5 +65,16 @@ contract SubaccountDepositIntent is IntentExecutorBase {
      */
     function _verifySubaccountOwner(uint256 subaccountId, address scw) internal view {
         if (MATCHING.subAccountToOwner(subaccountId) != scw) revert SubaccountOwnerMismatch();
+    }
+
+    /**
+     * @notice Set the allowed derive v2 asset
+     * @param deriveAsset The derive v2 asset address
+     * @param allowed Whether the derive v2 asset is allowed
+     */
+    function setAllowedDeriveAsset(address deriveAsset, bool allowed) external onlyOwner {
+        allowedDeriveAsset[deriveAsset] = allowed;
+
+        emit AllowedDeriveAssetSet(deriveAsset, allowed);
     }
 }

--- a/src/intents/SubaccountDepositIntent.sol
+++ b/src/intents/SubaccountDepositIntent.sol
@@ -2,10 +2,12 @@
 pragma solidity ^0.8.9;
 
 import {IERC20} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {IERC721} from "../../lib/openzeppelin-contracts/contracts/token/ERC721/IERC721.sol";
 import {IntentExecutorBase} from "./IntentExecutorBase.sol";
+import {ISubaccounts} from "../interfaces/ISubaccounts.sol";
 import {IERC20BasedAsset} from "../interfaces/derive/IERC20BasedAsset.sol";
 import {IMatching} from "../interfaces/derive/IMatching.sol";
+import {IStandardManager} from "../interfaces/derive/IStandardManager.sol";
+import {IPMRM2} from "../interfaces/derive/IPMRM2.sol";
 import {SafeERC20} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 
 /**
@@ -16,20 +18,37 @@ import {SafeERC20} from "../../lib/openzeppelin-contracts/contracts/token/ERC20/
 contract SubaccountDepositIntent is IntentExecutorBase {
     using SafeERC20 for IERC20;
 
+    /// @dev The matching contract user deposits their subaccounts into to trade on Derive.
     IMatching public immutable MATCHING;
+
+    /// @dev Derive Subaccounts
+    ISubaccounts public immutable SUBACCOUNTS;
+
+    /// @dev Special derive asset that's the base unit of the manager accounting system.
+    address public immutable CASH;
 
     error SubaccountOwnerMismatch();
     error DeriveAssetNotAllowed();
 
     event IntentDeposit(uint256 indexed subaccountId, address indexed scw, address indexed token, uint256 amount);
+    event ManagerTypeSet(address indexed manager, uint256 indexed managerType);
 
-    event AllowedDeriveAssetSet(address indexed deriveAsset, bool indexed allowed);
+    // The type of manager that is allowed to be used
+    enum ManagerType {
+        None,
+        Standard,
+        PM2
+    }
 
     // Derive v2 asset addresses that are allowed to be deposited for intent executors
-    mapping(address => bool) public allowedDeriveAsset;
+    mapping(address manager => ManagerType) public managerTypes;
 
-    constructor(IMatching _matching) {
+    constructor(IMatching _matching, address _cash) {
         MATCHING = _matching;
+
+        SUBACCOUNTS = ISubaccounts(_matching.subAccounts());
+
+        CASH = _cash;
     }
 
     /**
@@ -47,7 +66,7 @@ contract SubaccountDepositIntent is IntentExecutorBase {
         _verifySubaccountOwner(subaccountId, scw);
 
         // Can only deposit to derive v2 assets that are allowed
-        if (!allowedDeriveAsset[deriveAsset]) revert DeriveAssetNotAllowed();
+        if (!_isAllowedDeriveAsset(subaccountId, deriveAsset)) revert DeriveAssetNotAllowed();
 
         IERC20 token = IERC20BasedAsset(deriveAsset).wrappedAsset();
         token.safeTransferFrom(scw, address(this), amount);
@@ -69,12 +88,39 @@ contract SubaccountDepositIntent is IntentExecutorBase {
 
     /**
      * @notice Set the allowed derive v2 asset
-     * @param deriveAsset The derive v2 asset address
-     * @param allowed Whether the derive v2 asset is allowed
+     * @param manager The derive v2 manager
+     * @param managerType The type of manager
      */
-    function setAllowedDeriveAsset(address deriveAsset, bool allowed) external onlyOwner {
-        allowedDeriveAsset[deriveAsset] = allowed;
+    function setManagerTypes(address manager, ManagerType managerType) external onlyOwner {
+        managerTypes[manager] = managerType;
 
-        emit AllowedDeriveAssetSet(deriveAsset, allowed);
+        emit ManagerTypeSet(manager, uint256(managerType));
+    }
+
+    /**
+     * @notice Check if the derive asset is valid given a subaccountId
+     * @dev   We first check if the subaccountId is managed by a legitimate manager, then based on manager type,
+     *        read the allowed derive asset list
+     * @param subaccountId subaccount ID
+     * @param deriveAsset address of the derive asset
+     */
+    function _isAllowedDeriveAsset(uint256 subaccountId, address deriveAsset) internal view returns (bool) {
+        if (deriveAsset == CASH) return true;
+
+        address manager = SUBACCOUNTS.manager(subaccountId);
+
+        ManagerType managerType = managerTypes[manager];
+
+        if (managerType == ManagerType.None) {
+            return false;
+        } else if (managerType == ManagerType.Standard) {
+            IStandardManager.AssetDetail memory params = IStandardManager(manager).assetDetails(deriveAsset);
+            return params.isWhitelisted;
+        } else if (managerType == ManagerType.PM2) {
+            IPMRM2.CollateralParameters memory params = IPMRM2(manager).getCollateralParameters(deriveAsset);
+            return params.isEnabled;
+        } else {
+            return false;
+        }
     }
 }

--- a/src/interfaces/ISubaccounts.sol
+++ b/src/interfaces/ISubaccounts.sol
@@ -8,4 +8,10 @@ import {IERC721} from "lib/openzeppelin-contracts/contracts/token/ERC721/IERC721
 
 interface ISubaccounts is IERC721 {
     function getBalance(uint256 subaccountId, address asset, uint256 subId) external view returns (uint256);
+
+    function manager(uint256 subaccountId) external view returns (address);
+
+    function lastAccountId() external view returns (uint256);
+
+    function createAccount(address owner, address _manager) external returns (uint256 newId);
 }

--- a/src/interfaces/derive/ICash.sol
+++ b/src/interfaces/derive/ICash.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.18;
+
+interface ICash {
+    function accrueInterest() external;
+
+    function calculateBalanceWithInterest(uint256 accountId) external returns (int256 balance);
+}

--- a/src/interfaces/derive/IMatching.sol
+++ b/src/interfaces/derive/IMatching.sol
@@ -3,4 +3,8 @@ pragma solidity ^0.8.18;
 
 interface IMatching {
     function subAccountToOwner(uint256 subAccountId) external view returns (address);
+
+    function subAccounts() external view returns (address);
+
+    function createSubAccount(address manager) external returns (uint256);
 }

--- a/src/interfaces/derive/IPMRM2.sol
+++ b/src/interfaces/derive/IPMRM2.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.18;
+
+interface IPMRM2 {
+    // Defined once per collateral
+    struct CollateralParameters {
+        bool isEnabled;
+        bool isRiskCancelling;
+        /// @dev % value of collateral to subtract from MM. Must be <= 1
+        uint256 MMHaircut;
+        /// @dev % value of collateral to subtract from IM. Added on top of MMHaircut. Must be <= 1
+        uint256 IMHaircut;
+    }
+
+    function getCollateralParameters(address collateral) external view returns (CollateralParameters memory);
+}

--- a/src/interfaces/derive/IStandardManager.sol
+++ b/src/interfaces/derive/IStandardManager.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.13;
+
+interface IStandardManager {
+    enum AssetType {
+        NotSet,
+        Option,
+        Perpetual,
+        Base
+    }
+
+    struct AssetDetail {
+        bool isWhitelisted;
+        AssetType assetType;
+        uint256 marketId;
+    }
+
+    function assetDetails(address asset) external view returns (AssetDetail memory);
+
+    function settlePerpsWithIndex(uint256 subaccountId) external;
+}

--- a/test/fork-tests/intent/SubaccountDepositIntent.t.sol
+++ b/test/fork-tests/intent/SubaccountDepositIntent.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-// solhint-disable contract-name-camelcase
+// solhint-disable contract-name-camelcase func-name-mixedcase
 pragma solidity ^0.8.18;
 
 import {Test} from "lib/forge-std/src/Test.sol";
@@ -51,6 +51,8 @@ contract FORK_LYRA_SubaccountDepositIntent is Test {
 
         // set executor as intent executor
         depositIntent.setIntentExecutor(executor, true);
+
+        depositIntent.setAllowedDeriveAsset(DAIAsset, true);
     }
 
     function test_DepositIntent() public onlyDeriveMainnet {
@@ -74,6 +76,23 @@ contract FORK_LYRA_SubaccountDepositIntent is Test {
         vm.startPrank(executor);
         vm.expectRevert(SubaccountDepositIntent.SubaccountOwnerMismatch.selector);
         depositIntent.executeDepositIntent(user, invalidSubaccount, DAIAsset, 10 ether);
+        vm.stopPrank();
+    }
+
+    function test_RevertIf_DeriveAssetNotAllowed() public onlyDeriveMainnet {
+        address mockedDeriveAsset = address(0x123);
+
+        vm.startPrank(executor);
+        vm.expectRevert(SubaccountDepositIntent.DeriveAssetNotAllowed.selector);
+        depositIntent.executeDepositIntent(user, subaccountId, mockedDeriveAsset, 10 ether);
+        vm.stopPrank();
+    }
+
+    function test_RevertIf_AllowDeriveAsset_CallByExecutor() public onlyDeriveMainnet {
+        // executor cannot call setAllowedDeriveAsset
+        vm.startPrank(executor);
+        vm.expectRevert(bytes("Ownable: caller is not the owner"));
+        depositIntent.setAllowedDeriveAsset(DAIAsset, true);
         vm.stopPrank();
     }
 

--- a/test/fork-tests/intent/SubaccountDepositIntent.t.sol
+++ b/test/fork-tests/intent/SubaccountDepositIntent.t.sol
@@ -7,8 +7,10 @@ import {Test} from "lib/forge-std/src/Test.sol";
 import {SubaccountDepositIntent} from "src/intents/SubaccountDepositIntent.sol";
 import {IntentExecutorBase} from "src/intents/IntentExecutorBase.sol";
 import {IERC20} from "../../../lib/openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
-import {ISubaccounts} from "./interfaces/ISubaccounts.sol";
+import {ISubaccounts} from "../../../src/interfaces/ISubaccounts.sol";
 import {IMatching} from "src/interfaces/derive/IMatching.sol";
+import {IStandardManager} from "src/interfaces/derive/IStandardManager.sol";
+import {ICash} from "src/interfaces/derive/ICash.sol";
 
 /**
  * forge test --fork-url https://rpc.lyra.finance -vvv
@@ -16,16 +18,20 @@ import {IMatching} from "src/interfaces/derive/IMatching.sol";
 contract FORK_LYRA_SubaccountDepositIntent is Test {
     // ERC20 token on derive mainnet
     address public immutable DAI = address(0xB56D58Ce246C31c4D3a3bFB354996FF28D081dB7);
+    address public immutable USDC = address(0x6879287835A86F50f784313dBEd5E5cCC5bb8481);
 
     // Derive v2 asset on derive mainnet
     address public immutable DAIAsset = address(0x67bB0B7c87Df9C5C433ac7eCADfa7396A2927fcF);
+    address public immutable cash = address(0x57B03E14d409ADC7fAb6CFc44b5886CAD2D5f02b);
 
     // Matching contract on derive mainnet
     IMatching public matching = IMatching(0xeB8d770ec18DB98Db922E9D83260A585b9F0DeAD);
     ISubaccounts public subaccounts = ISubaccounts(0xE7603DF191D699d8BD9891b821347dbAb889E5a5);
 
-    // Mock light account address: owner of Subaccount 1
-    uint256 public subaccountId = 15;
+    uint256 public subaccountId;
+    address public standardManager = address(0x28c9ddF9A3B29c2E6a561c1BC520954e5A33de5D);
+
+    // Any Smart wallet address
     address public user = address(0x03CdE1E0bc6C1e096505253b310Cf454b0b462FB);
 
     SubaccountDepositIntent public depositIntent;
@@ -41,18 +47,28 @@ contract FORK_LYRA_SubaccountDepositIntent is Test {
     }
 
     function setUp() public onlyDeriveMainnet {
-        depositIntent = new SubaccountDepositIntent(matching);
+        depositIntent = new SubaccountDepositIntent(matching, cash);
 
         deal(DAI, user, 10 ether);
+        deal(USDC, user, 1000 * 1e6);
 
         // user approves depositIntent to spend DAI
-        vm.prank(user);
+        vm.startPrank(user);
+
+        // create a new subaccount to make sure balances are clean
+        subaccountId = matching.createSubAccount(standardManager);
+
         IERC20(DAI).approve(address(depositIntent), type(uint256).max);
+        IERC20(USDC).approve(address(depositIntent), type(uint256).max);
+        vm.stopPrank();
 
         // set executor as intent executor
         depositIntent.setIntentExecutor(executor, true);
 
-        depositIntent.setAllowedDeriveAsset(DAIAsset, true);
+        // set DAIAsset as allowed derive asset
+        depositIntent.setManagerTypes(
+            0x28c9ddF9A3B29c2E6a561c1BC520954e5A33de5D, SubaccountDepositIntent.ManagerType.Standard
+        );
     }
 
     function test_DepositIntent() public onlyDeriveMainnet {
@@ -68,6 +84,29 @@ contract FORK_LYRA_SubaccountDepositIntent is Test {
 
         assertEq(erc20BalanceAfter, erc20BalanceBefore - 10 ether);
         assertEq(subaccountBalanceAfter, subaccountBalanceBefore + 10 ether);
+    }
+
+    function test_DepositIntent_Cash() public onlyDeriveMainnet {
+        // // make sure we don't have pending PNL that might change cash balance on next call
+        // IStandardManager(standardManager).settlePerpsWithIndex(subaccountId);
+        // ICash(cash).accrueInterest();
+
+        uint256 erc20BalanceBefore = IERC20(USDC).balanceOf(user);
+        uint256 subaccountBalanceBefore = subaccounts.getBalance(subaccountId, cash, 0);
+
+        uint256 amount = 1000 * 1e6;
+        uint256 amountInCash = 1000 ether;
+
+        vm.startPrank(executor);
+
+        depositIntent.executeDepositIntent(user, subaccountId, cash, amount);
+        vm.stopPrank();
+
+        uint256 erc20BalanceAfter = IERC20(USDC).balanceOf(user);
+        uint256 subaccountBalanceAfter = subaccounts.getBalance(subaccountId, cash, 0);
+
+        assertEq(erc20BalanceAfter, erc20BalanceBefore - amount);
+        assertEq(subaccountBalanceAfter, subaccountBalanceBefore + amountInCash);
     }
 
     function test_RevertIf_DepositToInvalidSubaccount() public onlyDeriveMainnet {
@@ -92,7 +131,7 @@ contract FORK_LYRA_SubaccountDepositIntent is Test {
         // executor cannot call setAllowedDeriveAsset
         vm.startPrank(executor);
         vm.expectRevert(bytes("Ownable: caller is not the owner"));
-        depositIntent.setAllowedDeriveAsset(DAIAsset, true);
+        depositIntent.setManagerTypes(standardManager, SubaccountDepositIntent.ManagerType.PM2);
         vm.stopPrank();
     }
 

--- a/test/fork-tests/withdraw/LyraWithdrawWrapperV2.t.sol
+++ b/test/fork-tests/withdraw/LyraWithdrawWrapperV2.t.sol
@@ -125,7 +125,7 @@ contract FORK_LYRA_LyraWithdrawalV2Test is Test {
 
     function test_fork_getFee() public onlyLyra {
         uint256 fee = wrapper.getFeeInToken(usdc, usdcController, usdc_Mainnet_Connector, 200_000);
-        assertGt(fee, 1e6);
+        assertGt(fee, 1e5);
         assertLt(fee, 300e6);
 
         fee = wrapper.getFeeInToken(usdc, usdcController, usdc_Arbi_Connector, 200_000);


### PR DESCRIPTION
## Fix
This fix adds a guardrail by the owner address, which can whitelist/blacklist DeriveAsset addresses that can be used for all executors. Therefore, even if the executor key is exploited, no malicious actions can be taken.