### PR TITLE
fix: [audit-low-1] Fail-open pattern on maxFee

### DIFF
--- a/src/intents/WithdrawBridgeIntent.sol
+++ b/src/intents/WithdrawBridgeIntent.sol
@@ -105,7 +105,7 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
         IERC20(token).safeTransferFrom(scw, address(this), amount);
         IERC20(token).safeApprove(address(SOCKET_WITHDRAW_WRAPPER), amount);
 
-        if (maxFee > 0) {
+        if (maxFee != type(uint256).max) {
             uint256 feeInToken = SOCKET_WITHDRAW_WRAPPER.getFeeInToken(token, controller, connector, gasLimit);
             if (feeInToken > maxFee) revert FeeTooHigh();
         }
@@ -143,7 +143,7 @@ contract WithdrawBridgeIntent is IntentExecutorBase {
         IERC20(token).safeTransferFrom(scw, address(this), amount);
         IERC20(token).safeApprove(address(IOFT_WITHDRAW_WRAPPER), amount);
 
-        if (maxFee > 0) {
+        if (maxFee != type(uint256).max) {
             uint256 feeInToken = IOFT_WITHDRAW_WRAPPER.getFeeInToken(token, amount, destEID);
             if (feeInToken > maxFee) revert FeeTooHigh();
         }

--- a/test/fork-tests/intent/WithdrawBridgeIntent.t.sol
+++ b/test/fork-tests/intent/WithdrawBridgeIntent.t.sol
@@ -83,6 +83,22 @@ contract FORK_LYRA_WithdrawBridgeIntent is Test {
         assertEq(erc20BalanceAfter, erc20BalanceBefore - 1 ether);
     }
 
+    function test_WithdrawIntent_NoMaxFee() public onlyDeriveMainnet {
+        // test we can withdraw to SCW owner
+        address owner = ILightAccount(scw).owner();
+
+        uint256 erc20BalanceBefore = IERC20(weETH).balanceOf(scw);
+
+        vm.startPrank(executor);
+        bridgeIntent.executeWithdrawIntentSocket(
+            scw, weETH, 1 ether, type(uint256).max, owner, weETHController, weETHConnector, 200000
+        );
+        vm.stopPrank();
+
+        uint256 erc20BalanceAfter = IERC20(weETH).balanceOf(scw);
+        assertEq(erc20BalanceAfter, erc20BalanceBefore - 1 ether);
+    }
+
     function test_WithdrawIntent_DRV() public onlyDeriveMainnet {
         uint256 erc20BalanceBefore = IERC20(drv).balanceOf(scw);
 


### PR DESCRIPTION
When maxFee is specified as zero, the smart contract will accept any fee. This fail-open behaviour is against security best practices. 

This PR change the input validation to require explicitly setting "maxFee" to uint256(-1) to bypass the fee